### PR TITLE
Add MNIST starter

### DIFF
--- a/mnist/README.md
+++ b/mnist/README.md
@@ -1,0 +1,104 @@
+# Unweave MNIST Starter
+
+This starter will help you train an MNIST model using Unweave and serverless infra.
+
+This MNIST code is taken from the official [PyTorch examples](https://github.com/pytorch/examples) where you can find more examples to try running with Unweave.
+
+## Run the starter on Unweave
+
+1. If you don't have Unweave CLI installed, you can get it from homebrew
+
+```bash
+$ brew install unweave/unweave/unweave
+==> Downloading https://github.com/unweave/cli/releases/download/v0.0.19/unweave_0.0.19_darwin_arm64.tar.gz
+Already downloaded: /Users/markwinter/Library/Caches/Homebrew/downloads/fb4b2b676e3b8680405f5094e438827fead5210146df54cc96aad0ea026ae1e3--unweave_0.0.19_darwin_arm64.tar.gz
+==> Installing unweave from unweave/unweave
+🍺  /opt/homebrew/Cellar/unweave/0.0.19: 5 files, 7.4MB, built in 1 second
+````
+
+2. Use the Unweave CLI to login, following the login flow in your browser.
+
+```bash
+$ unweave login
+? Do you want to open the browser to login? (Y/n)
+```
+
+3. Clone this repository and cd into this MNIST starter directory
+
+```bash
+$ git clone https://github.com/unweave/starters.git
+$ cd mnist
+```
+
+4. Initialise the directory with unweave and call this project `mnist-starter`
+
+```bash
+$ unweave init
+? Enter project name [mnist]: mnist-starter
+Created project mnist-starter
+Path:    	/Users/markwinter/Code/starters/mnist
+Project: 	mnist-starter
+```
+
+5. Run the training script with the Unweave CLI. This will create a zepl with your data and run it on our infrastructure.
+
+```bash
+$ unweave python main.py
+Executing command 'python main.py' in serverless zepl. Press Ctrl+C to cancel
+Executing...
+
+Created zepl "secret-got-rubbed-clock" with ID "a1bee62f-b4c9-44ac-a880-ec04d178b015"
+
+Starting zepl. Press Ctrl+C while it is running to cancel the run
+
+🔄 Initializing serverless compute node
+
+✅ Compute node assigned to zepl
+
+🔄 Syncing Unweave Store
+
+🔄 Building environment
+
+🚀 Zepl running. Fetching logs ...
+
+Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz
+Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz to ../data/MNIST/raw/train-images-idx3-ubyte.gz
+100.0%
+Extracting ../data/MNIST/raw/train-images-idx3-ubyte.gz to ../data/MNIST/raw
+...
+
+Train Epoch: 1 [0/60000 (0%)]	Loss: 2.329474
+Train Epoch: 1 [640/60000 (1%)]	Loss: 1.425063
+Train Epoch: 1 [1280/60000 (2%)]	Loss: 0.815459
+Train Epoch: 1 [1920/60000 (3%)]	Loss: 0.535510
+Train Epoch: 1 [2560/60000 (4%)]	Loss: 0.425536
+Train Epoch: 1 [3200/60000 (5%)]	Loss: 0.253121
+Train Epoch: 1 [3840/60000 (6%)]	Loss: 0.353541
+...
+
+🧹 Cleaning up
+
+✅ Zepl complete
+```
+
+6. Your MNIST training is complete! You can explore more helpful CLI commands
+
+```bash
+# Open the Unweave dashboard in your browser
+$ unweave open
+```
+
+```bash
+# Check the logs of a zepl
+$ unweave logs <zepl-id>
+```
+
+```bash
+# Check all your zepls
+$ unweave zepls
+```
+
+```bash
+# Run a zepl but immediately detach once it has successfully launched
+$ unweave -d python main.py
+```

--- a/mnist/README.md
+++ b/mnist/README.md
@@ -46,7 +46,9 @@ Executing...
 
 Created zepl "donkey-lie-poet-other" with ID "a5825ccc-9c83-4bb8-84a0-f16801ffaba1"
 
-Starting zepl. Press Ctrl+C while it is running to cancel the run
+Starting zepl
+Press Ctrl+C to cancel the zepl
+Press Ctrl+D to detach
 
 🔄 Initializing serverless compute node
 ✅ Compute node assigned to zepl
@@ -72,7 +74,21 @@ Train Epoch: 1 [59520/60000 (99%)]	Loss: 0.002070
 ✅ Zepl complete
 ```
 
-6. Your MNIST training is complete! You can explore more helpful CLI commands
+6. Your MNIST training is complete! You can now fetch the model that was saved in remote storage. In the future you'll be able to use the output of one zepl in another zepl.
+
+```bash
+$ unweave ls <zepl-id>
+Listing output for zepl "<zepl-id>"
+You can download a file using "unweave download <zepl-id> <file-path>"
+
+mnist_cnn.pt
+
+$ unweave download <zepl-id> mnist_cnn.pt
+Downloading object "mnist_cnn.pt" from zepl "<zepl-id>"
+Saved to local file "./mnist_cnn.pt"
+```
+
+7. Explore other unweave cli commands
 
 ```bash
 # Open the Unweave dashboard in your browser

--- a/mnist/README.md
+++ b/mnist/README.md
@@ -10,10 +10,7 @@ This MNIST code is taken from the official [PyTorch examples](https://github.com
 
 ```bash
 $ brew install unweave/unweave/unweave
-==> Downloading https://github.com/unweave/cli/releases/download/v0.0.19/unweave_0.0.19_darwin_arm64.tar.gz
-Already downloaded: /Users/markwinter/Library/Caches/Homebrew/downloads/fb4b2b676e3b8680405f5094e438827fead5210146df54cc96aad0ea026ae1e3--unweave_0.0.19_darwin_arm64.tar.gz
-==> Installing unweave from unweave/unweave
-🍺  /opt/homebrew/Cellar/unweave/0.0.19: 5 files, 7.4MB, built in 1 second
+==> Downloading ...
 ````
 
 2. Use the Unweave CLI to login, following the login flow in your browser.
@@ -40,44 +37,38 @@ Path:    	/Users/markwinter/Code/starters/mnist
 Project: 	mnist-starter
 ```
 
-5. Run the training script with the Unweave CLI. This will create a zepl with your data and run it on our infrastructure.
+5. Run the training script with the Unweave CLI. This will create a serverless compute node (`zepl`) with your data and run it.
 
 ```bash
 $ unweave python main.py
 Executing command 'python main.py' in serverless zepl. Press Ctrl+C to cancel
 Executing...
 
-Created zepl "secret-got-rubbed-clock" with ID "a1bee62f-b4c9-44ac-a880-ec04d178b015"
+Created zepl "donkey-lie-poet-other" with ID "a5825ccc-9c83-4bb8-84a0-f16801ffaba1"
 
 Starting zepl. Press Ctrl+C while it is running to cancel the run
 
 🔄 Initializing serverless compute node
-
 ✅ Compute node assigned to zepl
-
 🔄 Syncing Unweave Store
-
 🔄 Building environment
-
 🚀 Zepl running. Fetching logs ...
-
 Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz
-Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz to ../data/MNIST/raw/train-images-idx3-ubyte.gz
+Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz to ./uwstore/data/MNIST/raw/train-images-idx3-ubyte.gz
 100.0%
-Extracting ../data/MNIST/raw/train-images-idx3-ubyte.gz to ../data/MNIST/raw
+Extracting ./uwstore/data/MNIST/raw/train-images-idx3-ubyte.gz to ./uwstore/data/MNIST/raw
+
 ...
 
-Train Epoch: 1 [0/60000 (0%)]	Loss: 2.329474
-Train Epoch: 1 [640/60000 (1%)]	Loss: 1.425063
-Train Epoch: 1 [1280/60000 (2%)]	Loss: 0.815459
-Train Epoch: 1 [1920/60000 (3%)]	Loss: 0.535510
-Train Epoch: 1 [2560/60000 (4%)]	Loss: 0.425536
-Train Epoch: 1 [3200/60000 (5%)]	Loss: 0.253121
-Train Epoch: 1 [3840/60000 (6%)]	Loss: 0.353541
+Train Epoch: 1 [0/60000 (0%)]	Loss: 2.305400
+Train Epoch: 1 [640/60000 (1%)]	Loss: 1.359780
+Train Epoch: 1 [1280/60000 (2%)]	Loss: 0.830670
+Train Epoch: 1 [1920/60000 (3%)]	Loss: 0.605963
 ...
-
+Train Epoch: 1 [58240/60000 (97%)]	Loss: 0.020182
+Train Epoch: 1 [58880/60000 (98%)]	Loss: 0.017681
+Train Epoch: 1 [59520/60000 (99%)]	Loss: 0.002070
 🧹 Cleaning up
-
 ✅ Zepl complete
 ```
 

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -1,0 +1,138 @@
+# Original Source: https://github.com/pytorch/examples/tree/main/mnist
+from __future__ import print_function
+import argparse
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+from torchvision import datasets, transforms
+from torch.optim.lr_scheduler import StepLR
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.dropout1 = nn.Dropout(0.25)
+        self.dropout2 = nn.Dropout(0.5)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = self.conv2(x)
+        x = F.relu(x)
+        x = F.max_pool2d(x, 2)
+        x = self.dropout1(x)
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.dropout2(x)
+        x = self.fc2(x)
+        output = F.log_softmax(x, dim=1)
+        return output
+
+
+def train(args, model, device, train_loader, optimizer, epoch):
+    model.train()
+    for batch_idx, (data, target) in enumerate(train_loader):
+        data, target = data.to(device), target.to(device)
+        optimizer.zero_grad()
+        output = model(data)
+        loss = F.nll_loss(output, target)
+        loss.backward()
+        optimizer.step()
+        if batch_idx % args.log_interval == 0:
+            print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
+                epoch, batch_idx * len(data), len(train_loader.dataset),
+                100. * batch_idx / len(train_loader), loss.item()))
+            if args.dry_run:
+                break
+
+
+def test(model, device, test_loader):
+    model.eval()
+    test_loss = 0
+    correct = 0
+    with torch.no_grad():
+        for data, target in test_loader:
+            data, target = data.to(device), target.to(device)
+            output = model(data)
+            test_loss += F.nll_loss(output, target, reduction='sum').item()  # sum up batch loss
+            pred = output.argmax(dim=1, keepdim=True)  # get the index of the max log-probability
+            correct += pred.eq(target.view_as(pred)).sum().item()
+
+    test_loss /= len(test_loader.dataset)
+
+    print('\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n'.format(
+        test_loss, correct, len(test_loader.dataset),
+        100. * correct / len(test_loader.dataset)))
+
+
+def main():
+    # Training settings
+    parser = argparse.ArgumentParser(description='PyTorch MNIST Example')
+    parser.add_argument('--batch-size', type=int, default=64, metavar='N',
+                        help='input batch size for training (default: 64)')
+    parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
+                        help='input batch size for testing (default: 1000)')
+    parser.add_argument('--epochs', type=int, default=1, metavar='N',
+                        help='number of epochs to train (default: 14)')
+    parser.add_argument('--lr', type=float, default=1.0, metavar='LR',
+                        help='learning rate (default: 1.0)')
+    parser.add_argument('--gamma', type=float, default=0.7, metavar='M',
+                        help='Learning rate step gamma (default: 0.7)')
+    parser.add_argument('--no-cuda', action='store_true', default=False,
+                        help='disables CUDA training')
+    parser.add_argument('--dry-run', action='store_true', default=False,
+                        help='quickly check a single pass')
+    parser.add_argument('--seed', type=int, default=1, metavar='S',
+                        help='random seed (default: 1)')
+    parser.add_argument('--log-interval', type=int, default=10, metavar='N',
+                        help='how many batches to wait before logging training status')
+    parser.add_argument('--save-model', action='store_true', default=False,
+                        help='For Saving the current Model')
+    args = parser.parse_args()
+    use_cuda = not args.no_cuda and torch.cuda.is_available()
+
+    torch.manual_seed(args.seed)
+
+    device = torch.device("cuda" if use_cuda else "cpu")
+
+    train_kwargs = {'batch_size': args.batch_size}
+    test_kwargs = {'batch_size': args.test_batch_size}
+    if use_cuda:
+        cuda_kwargs = {'num_workers': 1,
+                       'pin_memory': True,
+                       'shuffle': True}
+        train_kwargs.update(cuda_kwargs)
+        test_kwargs.update(cuda_kwargs)
+
+    transform=transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,))
+        ])
+    dataset1 = datasets.MNIST('../data', train=True, download=True,
+                       transform=transform)
+    dataset2 = datasets.MNIST('../data', train=False,
+                       transform=transform)
+    train_loader = torch.utils.data.DataLoader(dataset1,**train_kwargs)
+    test_loader = torch.utils.data.DataLoader(dataset2, **test_kwargs)
+
+    model = Net().to(device)
+    optimizer = optim.Adadelta(model.parameters(), lr=args.lr)
+
+    scheduler = StepLR(optimizer, step_size=1, gamma=args.gamma)
+    for epoch in range(1, args.epochs + 1):
+        train(args, model, device, train_loader, optimizer, epoch)
+        test(model, device, test_loader)
+        scheduler.step()
+
+    if args.save_model:
+        torch.save(model.state_dict(), "mnist_cnn.pt")
+
+
+if __name__ == '__main__':
+    main()

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -92,7 +92,7 @@ def main():
                         help='random seed (default: 1)')
     parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                         help='how many batches to wait before logging training status')
-    parser.add_argument('--save-model', action='store_true', default=False,
+    parser.add_argument('--save-model', action='store_true', default=True,
                         help='For Saving the current Model')
     args = parser.parse_args()
     use_cuda = not args.no_cuda and torch.cuda.is_available()
@@ -131,7 +131,7 @@ def main():
         scheduler.step()
 
     if args.save_model:
-        torch.save(model.state_dict(), "mnist_cnn.pt")
+        torch.save(model.state_dict(), "./uwstore/output/mnist_cnn.pt")
 
 
 if __name__ == '__main__':

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -114,9 +114,9 @@ def main():
         transforms.ToTensor(),
         transforms.Normalize((0.1307,), (0.3081,))
         ])
-    dataset1 = datasets.MNIST('../data', train=True, download=True,
+    dataset1 = datasets.MNIST('./uwstore/data', train=True, download=True,
                        transform=transform)
-    dataset2 = datasets.MNIST('../data', train=False,
+    dataset2 = datasets.MNIST('./uwstore/data', train=False,
                        transform=transform)
     train_loader = torch.utils.data.DataLoader(dataset1,**train_kwargs)
     test_loader = torch.utils.data.DataLoader(dataset2, **test_kwargs)

--- a/mnist/requirements.txt
+++ b/mnist/requirements.txt
@@ -1,0 +1,2 @@
+torch
+torchvision


### PR DESCRIPTION
Adding a simple mnist example. Added a brief tutorial in the REAMDE that users can follow

I changed the example from the pytorch one to:
- Only train 1 epoch, this is good enough for a demo
- Save model file by default, and save it to `./uwstore/output/model_cnn.pt`